### PR TITLE
Remove quotes in config, use a single `cat`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,12 +14,8 @@ quality = "${QUALITY}"
 client_id = "${CLIENT_ID}"
 client_secret = "${CLIENT_SECRET}"
 auth_token = "${AUTH_TOKEN}"
-EOF
-
-# Use optional variables, if present
-cat <<EOF >> /opt/config.py
-disable_ffmpeg = "${DISABLE_FFMPEG:-False}"
-refresh = "${REFRESH:-15}"
+disable_ffmpeg = ${DISABLE_FFMPEG:-False}
+refresh = ${REFRESH:-15}
 EOF
 
 # Hand off to the CMD


### PR DESCRIPTION
Hi!

I've merged your changes to my version and noticed the ones in `entrypoint.sh`. But there's a big issue (which you apparently kind of fixed for `refresh`), `disable_ffmpeg` will always act like `True` since it's a string!

In `twitch-recorder.py` when you do `if self.disable_ffmpeg` with a string, it will always run a copy, even if you've set the value to `"False"`.

Also not sure why there's two `cat` commands?